### PR TITLE
Added settings resets on world reset options to the wall macro

### DIFF
--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -26,6 +26,13 @@ global maxLoops := 20 ; increase if macro regularly locks up
 global scriptBootDelay := 6000 ; increase if instance freezes before world gen
 global oldWorldsFolder := "C:\MultiInstanceMC\oldWorlds\" ; Old Worlds folder, make it whatever you want
 
+; Preset settings variables to configure
+; Some sensitivity values may not work because of how Minecrafts settings bars work with arrow keys
+global resetSettings := True
+global renderDistance := 18
+global FOV := 90
+global mouseSensitivity := 50
+
 ; Don't configure these
 global instWidth := Floor(A_ScreenWidth / cols)
 global instHeight := Floor(A_ScreenHeight / rows)
@@ -254,6 +261,8 @@ ExitWorld()
     }
     ControlSend, ahk_parent, {Blind}{Esc}, ahk_pid %pid%
     ToWall()
+    if (resetSettings)
+      ResetSettings(idx)
     ResetInstance(idx)
   }
 }
@@ -325,6 +334,31 @@ ResetAll() {
   loop, %instances% {
     ResetInstance(A_Index)
   }
+}
+
+; Reset your settings to preset settings preferences
+ResetSettings(idx)
+{
+  pid := PIDs[idx]
+  ; Find required presses to set FOV, sensitivity, and render distance
+  FOVPresses := ceil((FOV-30)*1.7611)
+  SensPresses := ceil(mouseSensitivity/1.4)
+  RDPresses := renderDistance-2
+  ; Reset then preset render distance to custom value with f3 shortcuts
+  ControlSend, ahk_parent, {Blind}{Shift down}{F3 down}{F 32}{F3 up}{Shift up}, ahk_pid %pid%
+  ControlSend, ahk_parent, {Blind}{F3 down}{F %RDPresses%}{F3 up}, ahk_pid %pid%
+  ; Tab to FOV
+  ControlSend, ahk_parent, {Blind}{Esc}{Tab 6}{enter}{Tab}, ahk_pid %pid%
+  ; Reset then preset FOV to custom value with arrow keys
+  ControlSend, ahk_parent, {Blind}{Left 151}, ahk_pid %pid%
+  ControlSend, ahk_parent, {Blind}{Right %FOVPresses%}, ahk_pid %pid%
+  ; Tab to mouse sensitivity
+  ControlSend, ahk_parent, {Blind}{Tab 6}{enter}{tab}{enter}{tab}, ahk_pid %pid%
+  ; Reset then preset mouse sensitivity to custom value with arrow keys
+  ControlSend, ahk_parent, {Blind}{Left 146}, ahk_pid %pid%
+  ControlSend, ahk_parent, {Blind}{Right %SensPresses%}, ahk_pid %pid%
+  ; Escape
+  ControlSend, ahk_parent, {Blind}{Esc 3}, ahk_pid %pid%
 }
 
 RAlt::Suspend ; Pause all macros


### PR DESCRIPTION
You can configure all your settings at the top and the macro does the math to reset your settings before quitting a world so you don't have to do it yourself. Wont happen on normal resets, only leaving a world. This is legal.