### PR TITLE
Reset sounds fix

### DIFF
--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -17,7 +17,7 @@ global affinity := True ; A funky performance addition, enable for minor perform
 global wideResets := True
 global fullscreen := False
 global disableTTS := False
-; resetSounds option moved to reset.ahk, go there configure resetSounds
+; resetSounds option moved to reset.ahk, go there to configure resetSounds
 global lockSounds := True
 global countAttempts := True
 

--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -17,7 +17,7 @@ global affinity := True ; A funky performance addition, enable for minor perform
 global wideResets := True
 global fullscreen := False
 global disableTTS := False
-global resetSounds := True ; :)
+; resetSounds option moved to reset.ahk, go there configure resetSounds
 global lockSounds := True
 global countAttempts := True
 
@@ -339,8 +339,6 @@ ResetInstance(idx) {
     If (FileExist(idleFile))
       FileDelete, %idleFile%
     Run, reset.ahk %pid% %logFile% %maxLoops% %bfd% %idleFile% %beforePauseDelay%
-    if (resetSounds)
-      SoundPlay, reset.wav
     Critical, On
     resetScriptTime.Push(A_TickCount)
     resetIdx.Push(idx)

--- a/reset.ahk
+++ b/reset.ahk
@@ -2,6 +2,11 @@
 SetKeyDelay, 0
 ; v0.3.2
 
+global resetSounds := True ; :)
+
+ if (resetSounds)
+      SoundPlay, reset.wav
+
 ControlSend, ahk_parent, {Blind}{Shift down}{Tab}{Shift up}{Enter}, ahk_pid %1%
 sleep, 1000
 while (True) {


### PR DESCRIPTION
move reset sounds to reset.ahk, way faster because the macro doesn't have to wait for reset sounds to play before resetting another instance