### PR TITLE
Mostly lock indicators and websocket changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Add little locks or any image you want to signal when an instance is locked or n
 
 Note: Depends on OBS Websocket
 
-1) Add an image source to your wall scene in OBS for each instance and name them accordingly (lock1, lock2, lock3...) and position them where you want them to be. For example: ![lock](https://cdn.discordapp.com/attachments/853382176937345056/988725409233395743/unknown.png)
+1) Add an image source to your wall scene in OBS for each instance and name them accordingly (lock1, lock2, lock3...) and position them where you want them to be. For example: ![walllocks](https://user-images.githubusercontent.com/60681673/174759119-e4822c08-6ce1-4b8e-b345-68b15cd23aa9.png)
+![locksources](https://user-images.githubusercontent.com/60681673/174758616-d960a51e-c355-4cb9-b748-7b63420731a0.png)
 2) Edit the 2 extra settings in obsSettings.py accordingly. For lock_indicator_format put the prefix you used for your lock image sources in OBS.
 3) Set lockIndicators in settings.ahk to "True"
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Note: If you don't want you use Tinder, ignore anything related to it below.
 
 After that it should be working. Open a ticket in the [Discord](https://discord.gg/tXxwrYw) if you have any issues or need clarification.
 
+## OBS Locked Instance Indicators
+
+Add little locks or any image you want to signal when an instance is locked or not
+
+Note: Depends on OBS Websocket
+
+1) Add an image source to your wall scene in OBS for each instance and name them accordingly (lock1, lock2, lock3...) and position them where you want them to be. For example: ![lock](https://cdn.discordapp.com/attachments/853382176937345056/988725409233395743/unknown.png)
+2) Edit the 2 extra settings in obsSettings.py accordingly. For lock_indicator_format put the prefix you used for your lock image sources in OBS.
+3) Set lockIndicators in settings.ahk to "True"
+
+After that it should be working. Remember you need to have done the entire OBS Websocket setup for this to work as well. Open a ticket in the [Discord](https://discord.gg/tXxwrYw) if you have any issues or need clarification.
+
 ## Credit
 
 - Me

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -26,7 +26,7 @@ TinderMotion(swipeLeft) {
     LockInstance(currBg)
   newBg := GetFirstBgInstance(currBg)
   FileAppend, new:%newBg% old:%currBg%`n, log.log
-  obsOpsToBePushed .= "tm " . currBg . " " . newBg . "`n"
+  FileAppend, tm %currBg% %newBg%`n
   currBg := newBg
 }
 
@@ -180,7 +180,8 @@ SwitchInstance(idx, skipBg:=false, from:=-1)
   if (idx <= instances && FileExist(idleFile)) {
     FileDelete,instance.txt
     FileAppend,%idx%,instance.txt
-    locked[idx] := true
+    if !locked[idx]
+      locked[idx] := true
     if (useObsWebsocket) {
       prevBg := currBg
       currBg := GetFirstBgInstance(idx, skipBg)
@@ -193,9 +194,11 @@ SwitchInstance(idx, skipBg:=false, from:=-1)
         showMini := currBg
       }
       if (useSingleSceneOBS)
-        obsOpsToBePushed .= "ss-si " . from . " " . idx . " " . hideMini . " " . showMini . "`n"
+        FileAppend, ss-si %from% %idx% %hideMini% %showMini%`n
       Else
-        obsOpsToBePushed .= "si " . idx . "`n"
+        FileAppend, si %idx%`n, %obsFile%
+      if (lockIndicators)
+        FileAppend, li l %idx%`n, %liFile%
     }
     pid := PIDs[idx]
     if (affinity) {
@@ -282,7 +285,11 @@ ResetInstance(idx) {
     idleFile := McDirectories[idx] . "idle.tmp"
     killFile := McDirectories[idx] . "kill.tmp"
     FileAppend,,%killFile%
-    locked[idx] := false
+    if locked[idx] {
+      locked[idx] := false
+      if (lockIndicators && useObsWebsocket)
+        FileAppend, li u %idx%`n, %liFile%
+    }
     pid := PIDs[idx]
     if (performanceMethod == "F")
       ResumeInstance(pid)
@@ -328,9 +335,9 @@ ToWall(comingFrom) {
   WinActivate, Fullscreen Projector
   if (useObsWebsocket) {
     if (useSingleSceneOBS)
-      obsOpsToBePushed .= "ss-tw " . comingFrom . "`n"
+      FileAppend, ss-tw %comingFrom%`n
     Else
-      obsOpsToBePushed .= "tw`n"
+      FileAppend, tw`n, %obsFile%
   }
   else {
     send {F12 down}
@@ -340,28 +347,62 @@ ToWall(comingFrom) {
 }
 
 ; Focus hovered instance and background reset all other instances
-FocusReset(focusInstance) {
+FocusReset(focusInstance, bypassLock:=false) {
+  if (bypassLock && useObsWebsocket)
+    FileAppend, li u a`n, %liFile%
   SwitchInstance(focusInstance, true)
   loop, %instances% {
-    if (A_Index != focusInstance && !locked[A_Index]) {
-      ResetInstance(A_Index)
+    if (A_Index = focusInstance || (locked[A_Index] && !bypassLock)) {
+      Continue
     }
+    ResetInstance(A_Index)
   }
   needBgCheck := true
 }
 
 ; Reset all instances
-ResetAll() {
+ResetAll(bypassLock:=false) {
+  if (bypassLock && useObsWebsocket)
+    FileAppend, li u a`n, %liFile%
   loop, %instances% {
-    if (!locked[A_Index])
-      ResetInstance(A_Index)
+    if (locked[A_Index] && !bypassLock)
+      Continue
+    ResetInstance(A_Index)
   }
 }
 
 LockInstance(idx) {
   locked[idx] := true
+  if (lockIndicators && useObsWebsocket)
+    FileAppend, li l %idx%`n, %liFile%
   if (lockSounds)
     SoundPlay, A_ScriptDir\..\media\lock.wav
+}
+
+UnlockInstance(idx) {
+  locked[idx] := false
+  if (lockIndicators && useObsWebsocket)
+    FileAppend, li u %idx%`n, %liFile%
+  if (lockSounds)
+    SoundPlay, A_ScriptDir\..\media\unlock.wav
+}
+
+LockAll() {
+  loop, %instances%
+    locked[A_Index] := true
+  if (lockIndicators && useObsWebsocket)
+    FileAppend, li l a`n, %liFile%
+  if (lockSounds)
+    SoundPlay, A_ScriptDir\..\media\lock.wav
+}
+
+UnlockAll() {
+  loop, %instances%
+    locked[A_Index] := false
+  if (lockIndicators && useObsWebsocket)
+    FileAppend, li u a`n, %liFile%
+  if (lockSounds)
+    SoundPlay, A_ScriptDir\..\media\unlock.wav
 }
 
 ; Reset your settings to preset settings preferences

--- a/scripts/obsListener.py
+++ b/scripts/obsListener.py
@@ -5,10 +5,17 @@ import time
 import obsSettings as config
 
 ws = obsws(config.host, config.port, config.password)
-ws.connect()
+try:
+    ws.connect()
+    print("connected")
+except:
+    print("failed (reason unknown) to connect, exiting")
+    quit()
 
-last_completed_line = -1
-ops_file = "./obs.ops"
+last_completed_obs_line = -1
+last_completed_li_line = -1
+ops_file = "./scripts/obs.ops"
+li_file = "./scripts/li.ops"
 
 
 def tinderMotion(data):
@@ -39,8 +46,12 @@ def switchInstance(isSS, data):
         ws.call(requests.SetSceneItemProperties(
             f"{config.bg_mc_source_format}{hideMini}", visible=False))
     else:
-        ws.call(requests.SetCurrentScene(
-            f"{config.scene_name_format}{data[0]}"))
+        try:
+            ws.call(requests.SetCurrentScene(
+                f"{config.scene_name_format}{data[0]}"))
+            print("si "+data[0]+": "+str(ws.call(requests.SetCurrentScene(f"{config.scene_name_format}{data[0]}"))).split("called: ", 1)[1])
+        except:
+            print("si "+data[0]+": failed (reason unknown) (reason unknown)")
 
 
 def toWall(isSS, data):
@@ -52,26 +63,70 @@ def toWall(isSS, data):
         ws.call(requests.SetSceneItemProperties(
             f"{config.mc_source_format}{data[0]}", visible=False))
     else:
-        ws.call(requests.SetCurrentScene(f"{config.wall_scene_name}"))
+        try:
+            ws.call(requests.SetCurrentScene(f"{config.wall_scene_name}"))
+            print("tw: "+str(ws.call(requests.SetCurrentScene(f"{config.wall_scene_name}"))).split("called: ", 1)[1])
+        except:
+            print("tw: failed (reason unknown)")
+
+
+def lockIndicator(data):
+    lock, which = data
+    if lock == "l":
+        lock = True
+    else:
+        lock = False
+    if which == "a":
+        for i in range(config.instances):
+            try:
+                ws.call(requests.SetSceneItemProperties(
+                    f"{config.lock_indicator_format}{i+1}", visible=lock))
+                print("li "+str((i+1))+" "+str(lock)+": "+str(ws.call(requests.SetSceneItemProperties(f"{config.lock_indicator_format}{i+1}", visible=lock))).split("called: ",1)[1])
+            except:
+                print("li "+str((i+1))+" "+str(lock)+": failed (reason unknown)")
+    else:
+        try:
+            ws.call(requests.SetSceneItemProperties(
+                f"{config.lock_indicator_format}{which}", visible=lock))
+            print("li "+str(which)+" "+str(lock)+": "+str(ws.call(requests.SetSceneItemProperties(f"{config.lock_indicator_format}{which}", visible=lock))).split("called: ",1)[1])
+        except:
+            print("li "+str(which)+" "+str(lock)+": failed (reason unknown)")
 
 
 breaking = False
 while True:
+    if (os.path.exists(li_file)):
+        max_idx = sum(1 for _ in open(li_file)) - 1
+        if max_idx > last_completed_li_line:
+            with open(li_file) as li:
+                for i, line in enumerate(li):
+                    if i > last_completed_li_line:
+                        last_completed_li_line += 1
+                        splt = line.split(' ')
+                        splt[-1] = splt[-1].strip()
+                        op, args = splt[0], splt[1:]
+                        if op == "li":
+                            lockIndicator(args)
+                        else:
+                            print("Unexpected item in bagging area!")
     if (os.path.exists(ops_file)):
         max_idx = sum(1 for _ in open(ops_file)) - 1
-        if max_idx > last_completed_line:
+        if max_idx > last_completed_obs_line:
             with open(ops_file) as ops:
                 for i, line in enumerate(ops):
-                    if i > last_completed_line:
-                        last_completed_line += 1
+                    if i > last_completed_obs_line:
+                        last_completed_obs_line += 1
                         splt = line.split(' ')
                         splt[-1] = splt[-1].strip()
                         op, args = splt[0], splt[1:]
                         if op == "xx":
                             breaking = True
+                            print("stopping from \"xx\"")
                             break
                         elif op == "tm":
                             tinderMotion(args)
+                        elif op == "li":
+                            lockIndicator(args)
                         else:
                             isSS = op[:2] == "ss"
                             if op[-2] + op[-1] == "tw":
@@ -83,3 +138,4 @@ while True:
     time.sleep(1/config.checks_per_second)
 
 ws.disconnect()
+print("disconnected and exiting")

--- a/scripts/obsSettings.py
+++ b/scripts/obsSettings.py
@@ -7,6 +7,8 @@ checks_per_second = 2  # Increase if missing operations, decrease if lagging
 scene_name_format = "MultiMC-"  # Edit this
 mc_source_format = "mc "  # Edit this
 wall_scene_name = "Wall"    # Edit this
+instances = 4     # Edit this if you use lock indicators
+lock_indicator_format = "lock"  # Edit this if you use lock indicators
 
 # Single Scene Settings
 main_scene = "MainMulti"

--- a/scripts/reset.ahk
+++ b/scripts/reset.ahk
@@ -4,7 +4,7 @@ SetKeyDelay, 0
 ; v0.5
 
 started := A_NowUTC
-if (%resetSounds%)
+if (resetSounds)
   SoundPlay, A_ScriptDir\..\media\reset.wav
 saved := False
 FileDelete,%4%

--- a/settings.ahk
+++ b/settings.ahk
@@ -22,6 +22,7 @@ global useSingleSceneOBS := False ; Allows for simple OBS setup & Tinder. Requir
 global audioGui := False ; A simple GUI so the OBS application audio plugin can capture sounds
 global wallBypass := False ; If you have at least one locked instance, it will skip the wall and go to it
 global multiMode := False ; Never send you back to the wall unless there are no playable instances
+global lockIndicators := False ; OBS locked instance indicators (DEPENDS ON OBS WEBSOCKET)
 
 ; Settings reset settings
 ; Set to 0 if you dont want to settings reset


### PR DESCRIPTION
Changed the way websocket and obs.ops is handled in the macro for less chance of missed actions and added support for easy lock indicators. Also made a few changes to ResetAll and FocusReset.

Fixed not being able to disable resetSounds.

Added LockAll, UnlockInstance, and UnlockAll functions. (Not used by anything by default but can be used by hotkeys if user wants it.

Lock indicators use a separate ops file because using the same one causes lots of clashing and missed actions. Changed where both of the files are in the first place so they don't clog up the main folder as much. No more variable to keep track of what to push by the weird loop. Now it just directly adds to the file which seems to work completely fine. Also added a little stuff to the listener that can help debug if you run it without "hide" from TheWall.ahk.