### PR TITLE
Hold file lock bug

### DIFF
--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -69,7 +69,8 @@ for i, mcdir in McDirectories {
   idle := mcdir . "idle.tmp"
   hold := mcdir . "hold.tmp"
   preview := mcdir . "preview.tmp"
-  resetKey := CheckOptionsForHotkey(mcdir, "key_Create New World:key.keyboard.")
+  ;resetKey := CheckOptionsForHotkey(mcdir, "key_Create New World:key.keyboard.")
+  resetKey := atumResetKey
   resetkeys[i] := resetKey
   Run, %A_ScriptDir%\scripts\reset.ahk %pid% %logs% %idle% %hold% %preview% %resetKey%, %A_ScriptDir%,, rmpid
   DetectHiddenWindows, On

--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -69,8 +69,7 @@ for i, mcdir in McDirectories {
   idle := mcdir . "idle.tmp"
   hold := mcdir . "hold.tmp"
   preview := mcdir . "preview.tmp"
-  ;resetKey := CheckOptionsForHotkey(mcdir, "key_Create New World:key.keyboard.")
-  resetKey := atumResetKey
+  resetKey := CheckOptionsForHotkey(mcdir, "key_Create New World:key.keyboard.")
   resetkeys[i] := resetKey
   Run, %A_ScriptDir%\scripts\reset.ahk %pid% %logs% %idle% %hold% %preview% %resetKey%, %A_ScriptDir%,, rmpid
   DetectHiddenWindows, On

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -413,44 +413,6 @@ UnlockAll() {
     SoundPlay, A_ScriptDir\..\media\unlock.wav
 }
 
-; Reset your settings to preset settings preferences
-ResetSettings(pid, entering:=false)
-{
-  if (entering)
-    sleep, %settingsDelay%
-  if (doF1)
-    ControlSend,, {Blind}{F1}, ahk_pid %pid%
-  if (renderDistance)
-  {
-    if (!entering && performanceMethod == "S")
-      RDPresses := lowRender-2
-    else if ((!entering && performanceMethod != "S") || entering)
-      RDPresses := renderDistance-2
-    ; Reset then preset render distance to custom value with f3 shortcuts
-    ControlSend,, {Blind}{Shift down}{F3 down}{f 32}{Shift up}{f %RDPresses%}{d}{F3 up}, ahk_pid %pid%
-  }
-  if (FOV && !entering)
-  {
-    ; Tab to FOV reset then preset FOV to custom value with arrow keys
-    FOVPresses := ceil((110-FOV)*1.7875)
-    ControlSend,, {Blind}{Esc}{Tab 6}{enter}{Tab}{Right 150}{Left %FOVPresses%}{Esc}, ahk_pid %pid%
-  }
-  if (mouseSensitivity && !entering)
-  {
-    SensPresses := ceil(mouseSensitivity/1.408)
-    ; Tab to mouse sensitivity reset then preset mouse sensitivity to custom value with arrow keys
-    ControlSend,, {Blind}{Esc}{Tab 6}{enter}{Tab 7}{enter}{tab}{enter}{tab}{Left 150}{Right %SensPresses%}{Esc 3}, ahk_pid %pid%
-  }
-  if (entityDistance && !entering)
-  {
-    entityPresses := (5 - (entityDistance*.01)) * 143 / 4.5
-    ; Tab to video settings to reset entity distance
-    ControlSend,, {Blind}{Esc}{Tab 6}{enter}{Tab 6}{enter}{Tab 17}{Right 150}{Left %entityPresses%}{Esc 2}, ahk_pid %pid%
-  }
-  if (!entering)
-    sleep, %settingsDelay%
-}
-
 ; Shoutout peej
 global keyArray := Object("key.keyboard.f1", "F1"
 ,"key.keyboard.f2", "F2"

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -234,10 +234,9 @@ SwitchInstance(idx, skipBg:=false, from:=-1)
     }
     if (performanceMethod == "F")
       ResumeInstance(pid)
-    else if (performanceMethod == "S" || doF1) {
-      ControlSend,, {Blind}{Esc}, ahk_pid %pid%
-      ResetSettings(pid, true)
-    }
+    ControlSend,, {Blind}{Esc}, ahk_pid %pid%
+    if doF1
+      ControlSend,, {Blind}{F1}, ahk_pid %pid%
     WinSet, AlwaysOnTop, On, ahk_pid %pid%
     WinSet, AlwaysOnTop, Off, ahk_pid %pid%
     WinMinimize, Fullscreen Projector
@@ -291,7 +290,8 @@ ExitWorld()
       SwitchInstance(nextInst, false, idx)
     else
       ToWall(idx)
-    ResetSettings(pid)
+    if doF1
+      ControlSend,, {Blind}{F1}, ahk_pid %pid%
     ResetInstance(idx)
     if (affinity) {
       for i, tmppid in PIDs {

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -11,6 +11,10 @@ CheckOptionsForHotkey(mcdir, optionsCheck) {
     if (InStr(A_LoopReadLine, optionsCheck)) {
       split := StrSplit(A_LoopReadLine, ".")
       mi := split.MaxIndex()
+      if (split[mi] == "unknown") {
+        MsgBox, Missing hotkey for %optionsCheck%. Set hotkey in all instances and reopen macro.
+        ExitApp
+      }
       if (split[mi] == "period")
         return "."
       if (split[mi] == "comma")

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -24,6 +24,17 @@ CheckOptionsForHotkey(mcdir, optionsCheck) {
   }
 }
 
+CountAttempts(attemptType) {
+  file := attemptType . ".txt"
+  FileRead, WorldNumber, %file%
+  if (ErrorLevel)
+    WorldNumber = 0
+  else
+    FileDelete, %file%
+  WorldNumber += 1
+  FileAppend, %WorldNumber%, %file%
+}
+
 FindBypassInstance() {
   activeNum := GetActiveInstanceNum()
   for i, isLocked in locked {
@@ -320,20 +331,8 @@ ResetInstance(idx) {
     ; Count Attempts
     if (countAttempts)
     {
-      FileRead, WorldNumber, ATTEMPTS.txt
-      if (ErrorLevel)
-        WorldNumber = 0
-      else
-        FileDelete, ATTEMPTS.txt
-      WorldNumber += 1
-      FileAppend, %WorldNumber%, ATTEMPTS.txt
-      FileRead, WorldNumber, ATTEMPTS_DAY.txt
-      if (ErrorLevel)
-        WorldNumber = 0
-      else
-        FileDelete, ATTEMPTS_DAY.txt
-      WorldNumber += 1
-      FileAppend, %WorldNumber%, ATTEMPTS_DAY.txt
+      CountAttempts("ATTEMPTS")
+      CountAttempts("ATTEMPTS_DAY")
     }
   }
 }

--- a/scripts/reset.ahk
+++ b/scripts/reset.ahk
@@ -111,5 +111,7 @@ ManageReset() {
   if (performanceMethod == "F")
     sleep, %beforeFreezeDelay%
   FileAppend, %A_TickCount%, %idleFile%
+  if FileExist(holdFile)
+    FileDelete, %holdFile%
   return
 }

--- a/settings.ahk
+++ b/settings.ahk
@@ -2,7 +2,7 @@
 ; General settings
 global rows := 3 ; Number of row on the wall scene
 global cols := 3 ; Number of columns on the wall scene
-global performanceMethod := "S" ; F = Instance Freezing, S = Settings Changing RD, N = Nothing
+global performanceMethod := "N" ; F = Instance Freezing, N = Nothing
 global affinity := True ; A funky performance addition, enable for minor performance boost
 
 ; Extra features
@@ -19,15 +19,6 @@ global useSingleSceneOBS := False ; Allows for simple OBS setup & Tinder. (Addit
 global audioGui := False ; A simple GUI so the OBS application audio plugin can capture sounds
 global wallBypass := False ; If you have at least one locked instance, it will skip the wall and go to it
 global multiMode := False ; Never send you back to the wall unless there are no playable instances
-
-; Settings reset settings
-; Set to 0 if you dont want to settings reset
-; Sense and FOV may be off by 1, mess around with +-1 if you care about specifics
-global renderDistance := 18
-global entityDistance := 500
-global FOV := 110 ; For quake pro put 110
-global mouseSensitivity := 35
-global lowRender := 5 ; For settings change performance method
 global doF1 := False ; Toggle the f1 GUI hiding button on world join and reset
 
 ; Delays
@@ -38,7 +29,6 @@ global fullScreenDelay := 100 ; increse if fullscreening issues
 global restartDelay := 200 ; increase if saying missing instanceNumber in .minecraft (and you ran setup)
 global scriptBootDelay := 6000 ; increase if instance freezes before world gen
 global obsDelay := 100 ; increase if not changing scenes in obs
-global settingsDelay := 10 ; increase if settings arent changing
 global lowBitmaskMultiplier := 0.75 ; for affinity, find a happy medium, max=1.0
 global tinderCheckBuffer := 5 ; When all instances cant reset, how often it checks for an instance in seconds
 global spawnProtection := 300 ; Prevent a new instance from being reset for this many milliseconds after the preview is visible

--- a/settings.ahk
+++ b/settings.ahk
@@ -3,7 +3,6 @@
 global rows := 3 ; Number of row on the wall scene
 global cols := 3 ; Number of columns on the wall scene
 global performanceMethod := "S" ; F = Instance Freezing, S = Settings Changing RD, N = Nothing
-global atumResetKey := "F6" ; Create New World hotkey in minecraft settings (latest atum version required)
 global affinity := True ; A funky performance addition, enable for minor performance boost
 
 ; Extra features

--- a/settings.ahk
+++ b/settings.ahk
@@ -3,6 +3,7 @@
 global rows := 3 ; Number of row on the wall scene
 global cols := 3 ; Number of columns on the wall scene
 global performanceMethod := "S" ; F = Instance Freezing, S = Settings Changing RD, N = Nothing
+global atumResetKey := "F6" ; Create New World hotkey in minecraft settings (latest atum version required)
 global affinity := True ; A funky performance addition, enable for minor performance boost
 
 ; Extra features


### PR DESCRIPTION
Easy fix for rare bug where hold file gets created at the same time its deleted meaning an instance gets loaded and then can't reset. It still happens occasionally but now instead of needing to reload the macro you just have to wait for it to finish loading then you can reset it.