### PR TITLE
Instance verification, close instances, and affinity edits

### DIFF
--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -75,6 +75,7 @@ for i, mcdir in McDirectories {
   idle := mcdir . "idle.tmp"
   hold := mcdir . "hold.tmp"
   preview := mcdir . "preview.tmp"
+  VerifyInstance(mcdir, pid)
   resetKey := CheckOptionsForHotkey(mcdir, "key_Create New World", "F6")
   SendLog(LOG_LEVEL_INFO, Format("Found reset key: {1} for instance {2}", resetKey, i))
   resetkeys[i] := resetKey

--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -87,7 +87,7 @@ for i, mcdir in McDirectories {
   lpKey := CheckOptionsForHotkey(mcdir, "key_Leave Preview", "h")
   SendLog(LOG_LEVEL_INFO, Format("Found leave preview key: {1} for instance {2}", lpKey, i))
   lpKeys[i] := lpKey
-  Run, %A_ScriptDir%\scripts\reset.ahk %pid% %logs% %idle% %hold% %preview% %resetKey% %lpKey% %i%, %A_ScriptDir%,, rmpid
+  Run, %A_ScriptDir%\scripts\reset.ahk %pid% %logs% %idle% %hold% %preview% %resetKey% %lpKey% %i% %highBitMask% %midBitMask% %lowBitMask% %superLowBitMask%, %A_ScriptDir%,, rmpid
   DetectHiddenWindows, On
   WinWait, ahk_pid %rmpid%
   DetectHiddenWindows, Off
@@ -118,13 +118,15 @@ if (affinity) {
   }
 }
 
-if (!disableTTS)
-  ComObjCreate("SAPI.SpVoice").Speak("Ready")
-
 if audioGui {
   Gui, New
   Gui, Show,, The Wall Audio
 }
+
+Menu, Tray, Add, Close Instances, CloseInstances
+
+if (!disableTTS)
+  ComObjCreate("SAPI.SpVoice").Speak("Ready")
 
 #Persistent
 OnExit, ExitSub

--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -27,10 +27,15 @@ global resetKeys := []
 global lpKeys := []
 
 EnvGet, threadCount, NUMBER_OF_PROCESSORS
-global highBitMask := (2 ** threadCount) - 1
-global midBitMask := ((2 ** Ceil(threadCount * (.75 / affinityStrength))) - 1) < ((2 ** threadCount) - 1) ? ((2 ** Ceil(threadCount * (.75 / affinityStrength))) - 1) : ((2 ** threadCount) - 1)
-global lowBitMask := ((2 ** Ceil(threadCount * (.35 / affinityStrength))) - 1) < ((2 ** threadCount) - 1) ? ((2 ** Ceil(threadCount * (.35 / affinityStrength))) - 1) : ((2 ** threadCount) - 1)
-global superLowBitMask := ((2 ** Ceil(threadCount * (.1 / affinityStrength))) - 1) < ((2 ** threadCount) - 1) ? ((2 ** Ceil(threadCount * (.1 / affinityStrength))) - 1) : ((2 ** threadCount) - 1)
+global highThreads := highThreadsOverride > 0 ? highThreadsOverride : threadCount
+global midThreads := midThreadsOverride > 0 ? midThreadsOverride : Ceil(threadCount * (.75 / affinityStrength)) < threadCount ? Ceil(threadCount * (.75 / affinityStrength)) : threadCount
+global lowThreads := lowThreadsOverride > 0 ? lowThreadsOverride : Ceil(threadCount * (.35 / affinityStrength)) < threadCount ? Ceil(threadCount * (.35 / affinityStrength)) : threadCount
+global superLowThreads := superLowThreadsOverride > 0 ? superLowThreadsOverride : Ceil(threadCount * (.1 / affinityStrength)) < threadCount ? Ceil(threadCount * (.1 / affinityStrength)) : threadCount
+
+global highBitMask := GetBitMask(highThreads)
+global midBitMask := GetBitMask(midThreads)
+global lowBitMask := GetBitMask(lowThreads)
+global superLowBitMask := GetBitMask(superLowThreads)
 
 global instWidth := Floor(A_ScreenWidth / cols)
 global instHeight := Floor(A_ScreenHeight / rows)

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -493,6 +493,87 @@ GetLineCount(file) {
   return lineNum
 }
 
+VerifyInstance(mcdir, pid) {
+  moddir := mcdir . "mods\"
+  optionsFile := mcdir . "options.txt"
+  atum := false
+  wp := false
+  standardSettings := false
+  fastReset := false
+  sleepBg := false
+  sodium := false
+  srigt := false
+  Loop, Files, %moddir%*.jar
+  {
+    if (InStr(A_LoopFileName, "atum"))
+      atum := true
+    else if (InStr(A_LoopFileName, "worldpreview"))
+      wp := true
+    else if (InStr(A_LoopFileName, "standardsettings"))
+      standardSettings := true
+    else if (InStr(A_LoopFileName, "fast-reset"))
+      fastReset := true
+    else if (InStr(A_LoopFileName, "sleepbackground"))
+      sleepBg := true
+    else if (InStr(A_LoopFileName, "sodium"))
+      sodium := true
+    else if (InStr(A_LoopFileName, "SpeedRunIGT"))
+      srigt := true
+    else if (InStr(A_LoopFileName, "krypton")) {
+      SendLog(LOG_LEVEL_ERROR, Format("Directory {1} includes incompatible mod: Krypton", moddir))
+      MsgBox, 4, Krypton Detected, Directory %moddir% includes incompatible mod: Krypton. Would you like to disable it and restart the instance?
+      IfMsgBox Yes
+        FixInstance("krypton", A_LoopFileFullPath, pid)
+    }
+  }
+  if !atum {
+    SendLog(LOG_LEVEL_ERROR, Format("Directory {1} missing required mod: atum. Macro will not work. Download: https://github.com/VoidXWalker/Atum/releases", moddir))
+    MsgBox, Directory %moddir% missing required mod: atum. Macro will not work. Download: https://github.com/VoidXWalker/Atum/releases
+  }
+  if !wp {
+    SendLog(LOG_LEVEL_ERROR, Format("Directory {1} missing required mod: World Preview. Macro will likely not work. Download: https://github.com/VoidXWalker/WorldPreview/releases", moddir))
+    MsgBox, Directory %moddir% missing required mod: World Preview. Macro will likely not work. Download: https://github.com/VoidXWalker/WorldPreview/releases
+  }
+  if !standardSettings {
+    SendLog(LOG_LEVEL_WARNING, Format("Directory {1} missing highly recommended mod standardsettings. Download: https://github.com/KingContaria/StandardSettings/releases", moddir))
+    MsgBox, Directory %moddir% missing highly recommended mod: standardsettings. Download: https://github.com/KingContaria/StandardSettings/releases
+  } else {
+    standardSettingsFile := mcdir . "config\standardoptions.txt"
+    FileRead, ssettings, %standardSettingsFile%
+    if InStr(standardSettingsFile, "fullscreen:true") {
+      ssettings := StrReplace(ssettings, "fullscreen:true", "fullscreen:false")
+      FileDelete, %standardSettingsFile%
+      FileAppend, ssettings, %standardSettingsFile%
+      SendLog(LOG_LEVEL_WARNING, Format("File {1} had fullscreen set true, macro requires it false. Automatically fixed", standardSettingsFile))
+    }
+    if InStr(standardSettingsFile, "pauseOnLostFocus:false") {
+      ssettings := StrReplace(ssettings, "pauseOnLostFocus:true", "pauseOnLostFocus:false")
+      FileDelete, %standardSettingsFile%
+      FileAppend, ssettings, %standardSettingsFile%
+      SendLog(LOG_LEVEL_WARNING, Format("File {1} had pauseOnLostFocus set true, macro requires it false. Automatically fixed", standardSettingsFile))
+    }
+  }
+  if !fastReset
+    SendLog(LOG_LEVEL_WARNING, Format("Directory {1} missing recommended mod fast-reset. Download: https://github.com/jan-leila/FastReset/releases", moddir))
+  if !sleepBg
+    SendLog(LOG_LEVEL_WARNING, Format("Directory {1} missing recommended mod sleepbackground. Download: https://github.com/RedLime/SleepBackground/releases", moddir))
+  if !sodium
+    SendLog(LOG_LEVEL_WARNING, Format("Directory {1} missing recommended mod sodium. Download: https://github.com/jan-leila/sodium-fabric/releases", moddir))
+  if !srigt
+    SendLog(LOG_LEVEL_WARNING, Format("Directory {1} missing recommended mod SpeedRunIGT. Download: https://redlime.github.io/SpeedRunIGT/", moddir))
+  FileRead, options, %optionsFile%
+  if InStr(options, "fullscreen:true")
+    ControlSend,, {Blind}{F11}, ahk_pid %pid%
+}
+
+FixInstance(fix, data, pid) {
+  if (fix == "krypton") {
+    FileMove, %data%, %data%.disabled
+    WinClose, ahk_pid %pid%
+    ; add restarting instance?
+  }
+}
+
 ; Shoutout peej
 global keyArray := Object("key.keyboard.f1", "F1"
 ,"key.keyboard.f2", "F2"

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -230,6 +230,10 @@ SetAffinity(pid, mask) {
   DllCall("CloseHandle", "Ptr", hProc)
 }
 
+GetBitMask(threads) {
+  return (2 ** threads) - 1
+}
+
 UnsuspendAll() {
   WinGet, all, list
   Loop, %all%

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -445,6 +445,10 @@ LockInstance(idx, sound:=true) {
   }
   if (lockSounds && sound)
     SoundPlay, A_ScriptDir\..\media\lock.wav
+  if affinity {
+    pid := PIDs[idx]
+    SetAffinity(pid, highBitMask)
+  }
 }
 
 UnlockInstance(idx, sound:=true) {
@@ -456,6 +460,10 @@ UnlockInstance(idx, sound:=true) {
   }
   if (lockSounds && sound)
     SoundPlay, A_ScriptDir\..\media\unlock.wav
+  if affinity {
+    pid := PIDs[idx]
+    SetAffinity(pid, midBitMask)
+  }
 }
 
 LockAll(sound:=true) {

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -119,7 +119,7 @@ GetMcDir(pid)
 GetPIDFromMcDir(mcdir) {
   for proc in ComObjGet("winmgmts:").ExecQuery("Select * from Win32_Process where ExecutablePath like ""%jdk%javaw.exe%""") {
     cmdLine := proc.Commandline
-    if(RegExMatch(cmdLine, "-Djava\.library\.path=(?P<Dir>[^\""]+?)(?:\/|\\)natives", instDir)) {
+    if (RegExMatch(cmdLine, "-Djava\.library\.path=(?P<Dir>[^\""]+?)(?:\/|\\)natives", instDir)) {
       StringTrimRight, rawInstDir, mcdir, 1
       thisInstDir := SubStr(StrReplace(instDir, "/", "\"), 21, StrLen(instDir)-28) . "\.minecraft"
       if (rawInstDir == thisInstDir)
@@ -231,7 +231,7 @@ SetAffinity(pid, mask) {
 }
 
 GetBitMask(threads) {
-  return (2 ** threads) - 1
+  return ((2 ** threads) - 1)
 }
 
 UnsuspendAll() {
@@ -286,7 +286,7 @@ SwitchInstance(idx, skipBg:=false, from:=-1)
     FileDelete,instance.txt
     FileAppend,%idx%,instance.txt
     pid := PIDs[idx]
-    if (affinity)
+    if affinity
       SetAffinities(true)
     LockInstance(idx, False)
     if (performanceMethod == "F")
@@ -351,7 +351,7 @@ ExitWorld()
     if doF1
       ControlSend,, {Blind}{F1}, ahk_pid %pid%
     ResetInstance(idx)
-    if (affinity) {
+    if affinity {
       SetAffinities()
     }
   }
@@ -473,17 +473,17 @@ UnlockInstance(idx, sound:=true) {
 LockAll(sound:=true) {
   loop, %instances% {
     LockInstance(A_Index, false)
-    if (lockSounds && sound)
-      SoundPlay, A_ScriptDir\..\media\lock.wav
   }
+  if (lockSounds && sound)
+    SoundPlay, A_ScriptDir\..\media\lock.wav
 }
 
 UnlockAll(sound:=true) {
   loop, %instances% {
     UnlockInstance(A_Index, false)
-    if (lockSounds && sound)
-      SoundPlay, A_ScriptDir\..\media\unlock.wav
   }
+  if (lockSounds && sound)
+    SoundPlay, A_ScriptDir\..\media\unlock.wav
 }
 
 PlayNextLock(focusReset:=false, bypassLock:=false) {

--- a/scripts/reset.ahk
+++ b/scripts/reset.ahk
@@ -21,12 +21,10 @@ global previewFile := A_Args[5]
 global resetKey := A_Args[6]
 global lpKey := A_Args[7]
 global idx := A_Args[8]
-
-EnvGet, threadCount, NUMBER_OF_PROCESSORS
-global highBitMask := (2 ** threadCount) - 1
-global midBitMask := ((2 ** Ceil(threadCount * (.75 / affinityStrength))) - 1) < ((2 ** threadCount) - 1) ? ((2 ** Ceil(threadCount * (.75 / affinityStrength))) - 1) : ((2 ** threadCount) - 1)
-global lowBitMask := ((2 ** Ceil(threadCount * (.35 / affinityStrength))) - 1) < ((2 ** threadCount) - 1) ? ((2 ** Ceil(threadCount * (.35 / affinityStrength))) - 1) : ((2 ** threadCount) - 1)
-global superLowBitMask := ((2 ** Ceil(threadCount * (.1 / affinityStrength))) - 1) < ((2 ** threadCount) - 1) ? ((2 ** Ceil(threadCount * (.1 / affinityStrength))) - 1) : ((2 ** threadCount) - 1)
+global highBitMask := A_Args[9]
+global midBitMask := A_Args[10]
+global lowBitMask := A_Args[11]
+global superLowBitMask := A_Args[12]
 
 global state := "unknown"
 global lastImportantLine := GetLineCount(logFile)

--- a/settings.ahk
+++ b/settings.ahk
@@ -32,3 +32,9 @@ global scriptBootDelay := 6000 ; increase if instance freezes before world gen
 global obsDelay := 100 ; increase if not changing scenes in obs
 global tinderCheckBuffer := 5 ; When all instances cant reset, how often it checks for an instance in seconds
 global spawnProtection := 100 ; Prevent a new instance from being reset for this many milliseconds after the preview is visible
+
+; Super advanced settings (Do not change unless you know exactly absolutely what you are doing)
+global highThreadsOverride := -1
+global midThreadsOverride := -1
+global lowThreadsOverride := -1
+global superLowThreadsOverride := -1


### PR DESCRIPTION
- Verify that instances are ready for macro use on macro start (would be good to find a way to not run it every time, maybe an option in advanced settings or smt)
- Tray option with confirmation MsgBox to close all instances (along with rms)
- Pass bitmasks to reset.ahk 
- BitMask thread override options and cleaner bitmask setting