### PR TITLE
auto set obs python install path if possible

### DIFF
--- a/TheWall.ahk
+++ b/TheWall.ahk
@@ -66,6 +66,22 @@ Loop, Files, %A_ScriptDir%\media\lock*.png
 SetTheme(theme)
 GetAllPIDs()
 
+if (obsControl == "C") {
+  EnvGet, userProfileDir, USERPROFILE
+  obsIni = %userProfileDir%\AppData\Roaming\obs-studio\global.ini
+  IniRead, pyDir, %obsIni%, Python, Path64bit, N
+  if (!FileExist(Format("{1}\python.exe", pyDir))) {
+    pyPath := RegExReplace(ComObjCreate("WScript.Shell").Exec("python -c ""import sys; print(sys.executable)""").StdOut.ReadAll(), " *(\n|\r)+","")
+    if (!FileExist(pyPath)) {
+      SendLog(LOG_LEVEL_WARNING, "Couldn't find Python path", A_TickCount)
+    } else {
+      SplitPath, pyPath,, pyDir
+      IniWrite, %pyDir%, %obsIni%, Python, Path64bit
+      SendLog(LOG_LEVEL_INFO, Format("Automatically set OBS Python install path to {1}", pyDir), A_TickCount)
+    }
+  }
+}
+
 for i, mcdir in McDirectories {
   pid := PIDs[i]
   logs := mcdir . "logs\latest.log"

--- a/scripts/functions.ahk
+++ b/scripts/functions.ahk
@@ -902,6 +902,7 @@ OpenToLAN() {
   Sleep, 100
   Send, {Text}gamemode creative
   Send, {Enter}{%commandkey%}
+  Sleep, 100
   Send, {Text}gamerule doImmediateRespawn true
   Send, {Enter}
 


### PR DESCRIPTION
doesn't work if OBS is open (because OBS only checks settings on startup, and overwrites any changes on close), so not the most user friendly thing currently